### PR TITLE
Adding Segment guide to Adobe.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Analytics 2.0 API endpoints and methods are described on our [Swagger UI](ht
 The [Reporting API Guide](reporting-guide.md) provides configuration guidance and best practices for the ```/reports``` endpoint.
 
 ## Segments API Guide
-The [Segments API Guide](https://github.com/AdobeDocs/analytics-2.0-apis/blob/master/segments.md) provides configuration guidance and best practices for the ```/segments``` endpoint.
+The [Segments API Guide](segments.md) provides configuration guidance and best practices for the ```/segments``` endpoint.
 
 ## Create a Virtual Report Suite
 View examples of requests to [create report suites](virtualreportsuites.md).

--- a/manifest-docs.json
+++ b/manifest-docs.json
@@ -60,6 +60,12 @@
           "title": "Calculated Metrics"
     },
     {
+          "importedFileName": "segments",
+          "pages": [],
+          "path": "AdobeDocs/analytics-2.0-apis/master/segments.md",
+          "title": "Segments"
+    },
+    {
           "importedFileName": "virtual-report",
           "pages": [],
           "path": "AdobeDocs/analytics-2.0-apis/master/virtualreportsuites.md",


### PR DESCRIPTION
The links were not correct and the page was not added to the manifest

