### PR TITLE
Fix the spelling of Github to GitHub

### DIFF
--- a/support.md
+++ b/support.md
@@ -6,7 +6,7 @@ Learn where to ask questions, report bugs, make feature requests, and spark disc
 
 A knowledge base of frequently asked questions. This is a great starting place to find an answer before asking your question.
 
-## [Github Issues](https://github.com/AdobeDocs/analytics-2.0-apis/issues)
+## [GitHub Issues](https://github.com/AdobeDocs/analytics-2.0-apis/issues)
 
 This is the place to report bugs, ask questions, make feature requests, or start a discussion. You'll find official Adobe developers and community members available to help you out.
 


### PR DESCRIPTION
Super minor change to fix my own mistake - apparently it's spelled GitHub _:shrug:_