### PR TITLE
typo: code section ends early

### DIFF
--- a/segments-guide.md
+++ b/segments-guide.md
@@ -320,10 +320,7 @@ The following response shows validation for the segment with `rsid`: `obunpurser
   "supported_features": \[
     "function_attr",
     "function_container",
-
-```
-
-
     "function_streq"
   ]
 }
+```


### PR DESCRIPTION
simple typo, the code section looks like it ended too early

## Description

simple md typo

## Related Issue

no issue

## Motivation and Context

typo

## How Has This Been Tested?

not tested

## Screenshots (if appropriate):

## Types of changes

trivial documentation change

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
