### PR TITLE
adding discovery to the manifest

### DIFF
--- a/manifest-docs.json
+++ b/manifest-docs.json
@@ -92,6 +92,12 @@
           "title": "Segments APIs"
     },
     {
+          "importedFileName": "discovery",
+          "pages": [],
+          "path": "AdobeDocs/analytics-2.0-apis/master/discovery.md",
+          "title": "Discovery"
+    },
+    {
           "importedFileName": "faq",
           "pages": [],
           "path": "AdobeDocs/analytics-2.0-apis/master/faq.md",


### PR DESCRIPTION
Fixing a broken link in the adobe.io docs


