### PR TITLE
More obvious call-out that ECID seed functionality must..

### DIFF
--- a/bdia.md
+++ b/bdia.md
@@ -180,9 +180,11 @@ File size will vary according to the average size of each row.  While we recomme
 
 ## Customer ID and Experience Cloud Visitor ID Seeds
 
-BDIA provides a way for a customer ID to be specified which Adobe will use as a seed to automatically generate an Experience Cloud Visitor ID (ecid, formerly called Marketing Cloud Visitor ID or mid). This functionality simplifies the process of generating your own ecid, which would require a separate server call for every visitor. Providing your own customer ID as a seed for an ecid is done by adding a column to specify a "customerID.[customerIDType].id" and another boolean column, "customerID.[customerIDType].ismcseed" to denote which customer ID should be used as the seed. Other columns can be used to further define the customer ID as well. See the table below for more information about the available columns.
+*Note: In order to utilize this feature, we must coordinate with the Audience Manager team to have the report-suite configured for ECID auto-generation, and make some configuration changes to BDIA to support this feature. Please have your customer support contact or consultant reach out to our team to instigate this onboarding process.
 
-*Note: In order to utilize this feature, we must coordinate with the Audience Manager team to have the report-suite configured for ECID auto-generation, and make some configuration changes to BDIA to support this feature. Please have your customer support contact or consultant reach out to our team to instigate this onboarding process. **One element of the Audience Manager configuration is an "Integration Code". This will be the same string as your "customerIDType".**
+BDIA provides a way for a customer ID to be specified which Adobe will use as a seed to automatically generate an Experience Cloud Visitor ID (ECID, formerly called Marketing Cloud Visitor ID, MID, or MCID). This functionality simplifies the process of generating your own ECID, which would require a separate server call for every visitor. Providing your own customer ID as a seed for an ECID is done by adding a column to specify a "customerID.[customerIDType].id" and another boolean column, "customerID.[customerIDType].ismcseed" to denote which customer ID should be used as the seed. Other columns can be used to further define the customer ID as well. See the table below for more information about the available columns.
+
+ **One element of the Audience Manager configuration is an "Integration Code". This will be the same string as your "customerIDType".**
 
 ### Customer ID Columns and Query String Parameters
 


### PR DESCRIPTION
be provisioned before use.  A few clients failed to notice this direction before implementation.