### PR TITLE
Use the AnalyticsSegmentDefinition for ReportFilter's segmentDefinition

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5309,9 +5309,7 @@
         },
         "segmentDefinition": {
           "type": "object",
-          "additionalProperties": {
-            "type": "object"
-          }
+          "$ref": "#/definitions/AnalyticsSegmentDefinition"
         },
         "dateRange": {
           "type": "string"


### PR DESCRIPTION
Update API JSON schema to use a more strict definition.

## Description

`ReportFilter`'s `segmentDefinition` to use `AnalyticsSegmentDefinition`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#357

## Motivation and Context

Find more accurate information about the data schema you can use in request body of reports API.

## ~~How Has This Been Tested?~~

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## ~~Screenshots (if appropriate):~~

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
