### PR TITLE
AN-341340 Add forecasting related changes to reports endpoint

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5174,6 +5174,9 @@
         "includeAnomalyDetection": {
           "type": "boolean"
         },
+        "includeForecasting": {
+          "type": "boolean"
+        },
         "includePercentChange": {
           "type": "boolean"
         },
@@ -5494,6 +5497,27 @@
         "longitude": {
           "type": "number",
           "format": "double"
+        },
+        "dataForecasted": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "dataForecastedUpperBound": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "dataForecastedLowerBound": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
         }
       }
     },


### PR DESCRIPTION
## Description

- Added `includeForecasting` to RankedSettings in the request.

- Added `dataForecasted`, `dataForecastedUpperBound` and `dataForecastedLowerBound` in the response. These will be populated for all rows corresponding to future dates if the request has `includeForecasting` enabled (Meaning this is forecasting request).

More info here:
https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=scservices&title=Data+Forecasting+in+CJA

## Checklist

- [x] I have reviewed and signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] I have read and agree to the [CONTRIBUTING](CONTRIBUTING.md) document.
