### PR TITLE
AN-335075 Add realtime report endpoint for analytics

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3005,6 +3005,49 @@
         }
       }
     },
+     "/reports/realtime": {
+      "post": {
+        "tags": [
+          "Reports"
+        ],
+        "summary": "Runs a Real time report for the request in the post body",
+        "description": "This section will be updated with new real time reporting Guide.",
+        "operationId": "runRealTimeReport",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RankedRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "schema": {
+              "$ref": "#/definitions/RankedReportData"
+            }
+          },
+          "400": {
+            "description": "Invalid input; Valid metric, dimension, rsid and Real-time config for rsid are required. Definition must be formatted as a JSON Object.",
+            "schema": {
+              "$ref": "#/definitions/ReportErrorStatus"
+            }
+          },
+          "403" : {
+            "description" : "User should have access to the metrics and dimensions used in the request"
+          }
+        }
+      }
+    },
     "/reports/topItems": {
       "get": {
         "tags": [


### PR DESCRIPTION
## Description
This change adds a new endpoint /reports/realtime which is available only for Analytics customers. This is planned as a replacement for the 1.4 real time time api.

## Checklist

- [x] I have reviewed and signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] I have read and agree to the [CONTRIBUTING](CONTRIBUTING.md) document.
