### PR TITLE
Revert "Bump @adobe/gatsby-theme-aio from 4.11.3 to 4.11.15"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/gigazelle"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "^4.11.15",
+    "@adobe/gatsby-theme-aio": "^4.11.3",
     "gatsby": "^4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,9 +33,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:^4.11.15":
-  version: 4.12.0
-  resolution: "@adobe/gatsby-theme-aio@npm:4.12.0"
+"@adobe/gatsby-theme-aio@npm:^4.11.3":
+  version: 4.11.3
+  resolution: "@adobe/gatsby-theme-aio@npm:4.11.3"
   dependencies:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
@@ -131,7 +131,7 @@ __metadata:
     gatsby: ^4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: dab219f34bdc2a9b402e9e0808ee00c2c935e7566872023c56951dd1790612e9ed39e461d9c2a47521c51007b2b333c46935e83eb9e23a82dcb894eab3a7bcba
+  checksum: 36b7256aba793747b6da40b867b8ad4ecd32835c1ea5bc76ee3fef5cd73d7aa14ba9734ef3c5a7db6866d806fc61afd02bf44053a1ffdd93ec8016cf130f84b7
   languageName: node
   linkType: hard
 
@@ -5146,7 +5146,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "analytics-2.0-apis@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": ^4.11.15
+    "@adobe/gatsby-theme-aio": ^4.11.3
     gatsby: ^4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
Reverts AdobeDocs/analytics-2.0-apis#502