### PR TITLE
AN-333363 Add support for relative dates for real time reports

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5363,6 +5363,9 @@
         "dateRange": {
           "type": "string"
         },
+        "dateRangeRelative": {
+          "type": "string"
+        },
         "excludeItemIds": {
           "type": "array",
           "items": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## This change is to support Relative Date Ranges for Real time reports for Analytics 2.0 API 

<!--- Describe your changes in detail -->

For real time reports, currently we only support dateRange which has absolute date range value for example `2024-01-01T00:00:00.000/2024-01-21T00:00:00.000`.

With this addition we support dateRangeRelative which will be of the format `from / to`. For example `20 minutes ago / now`. Below are the possible values for from and to.
 - minutes i.e. "20 minutes ago"
 - hours i.e. "1 hour ago"
 - "now"
 - "midnight"
 - "noon"
 - n AM/PM i.e. "3:45 PM" or "3 PM"
 - yesterday n AM/PM i.e. "yesterday 12:30 PM" or "yesterday 12 PM"

## Checklist

- [x] I have reviewed and signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] I have read and agree to the [CONTRIBUTING](CONTRIBUTING.md) document.
