### PR TITLE
Fix broken link in classifications import-file doc

### DIFF
--- a/src/pages/guides/endpoints/classifications/import-file.md
+++ b/src/pages/guides/endpoints/classifications/import-file.md
@@ -239,7 +239,7 @@ The following table describes the PUT upload file response parameters:
 
 ## POST import commit job ID
 
-Use this endpoint to commit the changes of a specified job ID. This endpoint finalizes the file uploading process. For more information on classification jobs, see [Classification set jobs manager](https://experienceleague.adobe.com/docs/analytics/components/classifications/sets/job-manager.htm).
+Use this endpoint to commit the changes of a specified job ID. This endpoint finalizes the file uploading process. For more information on classification jobs, see [Classification set jobs manager](https://experienceleague.adobe.com/docs/analytics/components/classifications/sets/job-manager.html).
 
 `POST https://analytics.adobe.io.api/{GLOBAL_COMPANY_ID}/classifications/job/import/commitApiJob/{API_JOB_ID}`
 


### PR DESCRIPTION
Closes #608. Adds the missing "l" to the .html extension in the Classification set jobs manager link, which currently resolves to a 404.