### PR TITLE
[AN-458317] Add Marketing Channels to the Top Nav API Reference menu

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -19,6 +19,7 @@
         - [Data Sources APIs](apis/data-sources.md)
         - [Data Warehouse APIs](apis/data-warehouse.md)
         - [Livestream APIs](apis/livestream.md)
+        - [Marketing Channels APIs](apis/marketing-channels.md)
         - [Report Suites APIs](apis/report-suites.md)
     - [Use cases](guides/use-cases/index.md)
     - [Support](support.md)


### PR DESCRIPTION
Add the Marketing Channels APIs entry to src/pages/config.md so the service appears in the API Reference dropdown. config.md is the EDS Top Nav config that renders the menu; adding the reference page and docs/index.html redirect alone was not enough.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [ ] I have reviewed and signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] I have read and agree to the [CONTRIBUTING](CONTRIBUTING.md) document.
