### PR TITLE
[AN-458317] Clean up Marketing Channels swagger field descriptions

### DIFF
--- a/static/marketing-channels.json
+++ b/static/marketing-channels.json
@@ -172,7 +172,7 @@
           },
           "type": {
             "type": "string",
-            "description": "The marketing channel type. Sample data shows \"online\"; the full set of allowed values is pending SME confirmation.",
+            "description": "The marketing channel type (for example, `online`).",
             "example": "online"
           },
           "color": {
@@ -183,7 +183,7 @@
           "channelBreakdown": {
             "type": "integer",
             "format": "int32",
-            "description": "Numeric indicator of how the channel is broken down in reporting. Sample data shows 0; meaning and range are pending SME confirmation.",
+            "description": "A numeric indicator of how the channel is broken down in reporting.",
             "example": 0
           },
           "overrideLastTouchChannel": {


### PR DESCRIPTION
Remove the "pending SME confirmation" notes from the type and channelBreakdown descriptions. Per the dev SME, both are passthrough (non-enum) fields: type can be any string and channelBreakdown any integer.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [ ] I have reviewed and signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] I have read and agree to the [CONTRIBUTING](CONTRIBUTING.md) document.
