### PR TITLE
[AN-458317] Match core AA 2.0 auth pattern in Marketing Channels swagger

### DIFF
--- a/static/marketing-channels.json
+++ b/static/marketing-channels.json
@@ -105,12 +105,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "x-user-auth": []
-          }
-        ]
+        }
       }
     }
   },
@@ -206,14 +201,6 @@
             "type": "string"
           }
         }
-      }
-    },
-    "securitySchemes": {
-      "x-user-auth": {
-        "type": "apiKey",
-        "description": "IMS user token",
-        "name": "x-user-auth",
-        "in": "header"
       }
     },
     "parameters": {


### PR DESCRIPTION
Remove the x-user-auth security scheme and the operation-level security requirement so the Try it panel matches the core endpoints (e.g. Dimensions). Authorization and x-api-key remain documented as header parameters. Fixes the extra "Security > x-user-auth" box in Try it.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [ ] I have reviewed and signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] I have read and agree to the [CONTRIBUTING](CONTRIBUTING.md) document.
