### PR TITLE
[AN-458317] Use "retrieve" and a concise endpoint title in Marketing …

### DIFF
--- a/static/marketing-channels.json
+++ b/static/marketing-channels.json
@@ -12,8 +12,7 @@
   ],
   "tags": [
     {
-      "name": "Marketing Channels",
-      "description": "Retrieve marketing channel configurations for report suites."
+      "name": "Marketing Channels"
     }
   ],
   "paths": {
@@ -22,7 +21,7 @@
         "tags": [
           "Marketing Channels"
         ],
-        "summary": "Get marketing channels for one or more report suites",
+        "summary": "Retrieve marketing channels for report suites",
         "description": "Retrieves the marketing channel configurations for one or more report suites. This endpoint uses the POST method (not GET) so that a list of report suite IDs can be supplied in the request body; it does not create or modify marketing channels.",
         "operationId": "getMarketingChannels",
         "parameters": [


### PR DESCRIPTION
…Channels swagger

Rename the endpoint summary to "Retrieve marketing channels for report suites" (retrieve, not get; shorter title used for the endpoint heading and nav). Remove the redundant tag description that rendered as a summary line between the service title and the endpoint name.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Checklist

- [ ] I have reviewed and signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] I have read and agree to the [CONTRIBUTING](CONTRIBUTING.md) document.
